### PR TITLE
Make pucket paritioned writer cache safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,29 @@ The following top level dependencies are published in Maven central:
 
 **Thrift support**:
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.0.6"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.1.0"
 ```
 
 **Avro support**:
 ```
-"com.intenthq.pucket" %% "pucket-avro" % "1.0.6"
+"com.intenthq.pucket" %% "pucket-avro" % "1.1.0"
 ```
 
 **Spark connectors**:
 ```
-"com.intenthq.pucket" %% "pucket-spark" % "1.0.6"
+"com.intenthq.pucket" %% "pucket-spark" % "1.1.0"
 ```
 
 **MapReduce integration**:
 ```
-"com.intenthq.pucket" %% "pucket-mapreduce" % "1.0.6"
+"com.intenthq.pucket" %% "pucket-mapreduce" % "1.1.0"
 ```
 
 These dependencies should be combined depending on your usages; for example if you use Thrift and Spark then use the following:
 
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.0.6"
-"com.intenthq.pucket" %% "pucket-spark" % "1.0.6"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-spark" % "1.1.0"
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ def excludeServlet(deps: Seq[ModuleID]) = deps.map(_.exclude("javax.servlet", "s
 
 lazy val commonSettings = Seq(
   organization := "com.intenthq.pucket",
-  version := "1.0.6",
-  scalaVersion := "2.11.7",
+  version := "1.1.0",
+  scalaVersion := "2.11.8",
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   publishTo := {

--- a/core/src/main/scala/com/intenthq/pucket/writer/IncrementalPartitionedWriter.scala
+++ b/core/src/main/scala/com/intenthq/pucket/writer/IncrementalPartitionedWriter.scala
@@ -54,5 +54,5 @@ object IncrementalPartitionedWriter {
     * @return a new incremental partitioned writer
     */
   def apply[T](pucket: Pucket[T], maxWrites: Long, writerCacheSize: Int = 100): IncrementalPartitionedWriter[T] =
-    IncrementalPartitionedWriter(pucket, Writers(Map[Path, IncrementalWriter[T]](), Map[Long, Path]()), maxWrites, writerCacheSize)
+    IncrementalPartitionedWriter(pucket, Writers(Map[String, IncrementalWriter[T]](), Map[Long, String]()), maxWrites, writerCacheSize)
 }

--- a/core/src/main/scala/com/intenthq/pucket/writer/PartitionedWriter.scala
+++ b/core/src/main/scala/com/intenthq/pucket/writer/PartitionedWriter.scala
@@ -43,5 +43,5 @@ object PartitionedWriter {
    * @return a new partitioned writer
    */
   def apply[T](pucket: Pucket[T], writerCacheSize: Int = 100): PartitionedWriter[T] =
-    PartitionedWriter(pucket, Writers[T, Throwable](Map[Path, Writer[T, Throwable]](), Map[Long, Path]()), writerCacheSize)
+    PartitionedWriter(pucket, Writers[T, Throwable](Map[String, Writer[T, Throwable]](), Map[Long, String]()), writerCacheSize)
 }

--- a/test/src/main/scala/com/intenthq/pucket/writer/IncrementalPartitionedWriterSpec.scala
+++ b/test/src/main/scala/com/intenthq/pucket/writer/IncrementalPartitionedWriterSpec.scala
@@ -45,7 +45,7 @@ trait IncrementalPartitionedWriterSpec[T] extends Specification with Disjunction
       filterNot(_.getName == PucketDescriptor.descriptorFilename)))
 
   def writer: Throwable \/ IncrementalPartitionedWriter[T] =
-    wrapper.pucket.map(IncrementalPartitionedWriter(_, maxWrites))
+    wrapper.pucket.map(IncrementalPartitionedWriter(_, maxWrites, 5))
 
 }
 

--- a/test/src/main/scala/com/intenthq/pucket/writer/PartitionedWriterSpec.scala
+++ b/test/src/main/scala/com/intenthq/pucket/writer/PartitionedWriterSpec.scala
@@ -40,7 +40,7 @@ trait PartitionedWriterSpec[T] extends Specification with DisjunctionMatchers wi
       map(_.getPath.getName).
       filterNot(_ == PucketDescriptor.descriptorFilename)))
 
-  def writer: Throwable \/ PartitionedWriter[T] = wrapper.pucket.map(PartitionedWriter(_))
+  def writer: Throwable \/ PartitionedWriter[T] = wrapper.pucket.map(PartitionedWriter(_, 5))
 }
 
 object PartitionedWriterSpec {


### PR DESCRIPTION
- use options for getting writers out of the maps
- update partitioned writer tests so the writer cache is reduced
