### PR TITLE
Change the hadoop config source for spark adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,29 @@ The following top level dependencies are published in Maven central:
 
 **Thrift support**:
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.2.0"
 ```
 
 **Avro support**:
 ```
-"com.intenthq.pucket" %% "pucket-avro" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-avro" % "1.2.0"
 ```
 
 **Spark connectors**:
 ```
-"com.intenthq.pucket" %% "pucket-spark" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-spark" % "1.2.0"
 ```
 
 **MapReduce integration**:
 ```
-"com.intenthq.pucket" %% "pucket-mapreduce" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-mapreduce" % "1.2.0"
 ```
 
 These dependencies should be combined depending on your usages; for example if you use Thrift and Spark then use the following:
 
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.1.0"
-"com.intenthq.pucket" %% "pucket-spark" % "1.1.0"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.2.0"
+"com.intenthq.pucket" %% "pucket-spark" % "1.2.0"
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ def excludeServlet(deps: Seq[ModuleID]) = deps.map(_.exclude("javax.servlet", "s
 
 lazy val commonSettings = Seq(
   organization := "com.intenthq.pucket",
-  version := "1.1.0",
+  version := "1.2.0",
   scalaVersion := "2.11.8",
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },

--- a/test/src/main/scala/com/intenthq/pucket/spark/PucketSparkAdapterSpec.scala
+++ b/test/src/main/scala/com/intenthq/pucket/spark/PucketSparkAdapterSpec.scala
@@ -42,7 +42,7 @@ abstract class PucketSparkAdapterSpec[T, Descriptor](registrator: Option[String]
     case a => a must containAllOf(data)
   }
 
-  def writeOut = pucket.map(x => x.toRDD.saveAsPucket(outputPath, x.descriptor)) must be_\/-.like {
+  def writeOut = pucket.map(x => x.toRDD.saveAsPucket(outputPath, x.descriptor, Some(x.conf))) must be_\/-.like {
     case _ => findPucket(outputPath) must be_\/-.like {
       case p => readData(data, p) must be_\/-.like {
         case a => a must containAllOf(data)


### PR DESCRIPTION
- used to default to the config in the spark context
- now merges the one in spark context and the one in the pucket (pucket takes precidence)
- when saving as a pucket an optional hadoop config can be supplied
