### PR TITLE
Upgrade dependencies, bump to 1.7.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,29 @@ The following top level dependencies are published in Maven central:
 
 **Thrift support**:
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.6.0"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.7.0"
 ```
 
 **Avro support**:
 ```
-"com.intenthq.pucket" %% "pucket-avro" % "1.6.0"
+"com.intenthq.pucket" %% "pucket-avro" % "1.7.0"
 ```
 
 **Spark connectors**:
 ```
-"com.intenthq.pucket" %% "pucket-spark" % "1.6.0"
+"com.intenthq.pucket" %% "pucket-spark" % "1.7.0"
 ```
 
 **MapReduce integration**:
 ```
-"com.intenthq.pucket" %% "pucket-mapreduce" % "1.6.0"
+"com.intenthq.pucket" %% "pucket-mapreduce" % "1.7.0"
 ```
 
 These dependencies should be combined depending on your usages; for example if you use Thrift and Spark then use the following:
 
 ```
-"com.intenthq.pucket" %% "pucket-thrift" % "1.6.0"
-"com.intenthq.pucket" %% "pucket-spark" % "1.6.0"
+"com.intenthq.pucket" %% "pucket-thrift" % "1.7.0"
+"com.intenthq.pucket" %% "pucket-spark" % "1.7.0"
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ import com.typesafe.sbt.SbtGit.GitKeys._
 
 val specs2Ver = "3.8.6"
 val parquetVer = "1.8.1"
-val hadoopVer = "2.7.3"
-val sparkVer = "2.1.0"
-val circeVersion = "0.7.0"
-val scalazVersion = "7.2.9"
+val hadoopVer = "2.7.4"
+val sparkVer = "2.1.2"
+val circeVersion = "0.8.0"
+val scalazVersion = "7.2.16"
 
 val pomInfo = (
   <url>https://github.com/intenthq/pucket</url>
@@ -32,8 +32,8 @@ val pomInfo = (
 
 lazy val commonSettings = Seq(
   organization := "com.intenthq.pucket",
-  version := "1.6.0",
-  scalaVersion := "2.11.8",
+  version := "1.7.0",
+  scalaVersion := "2.11.12",
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   publishTo := {
@@ -48,10 +48,10 @@ lazy val commonSettings = Seq(
   autoAPIMappings := true,
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-common" % hadoopVer % "provided,test",
-    "org.slf4j" % "slf4j-api" % "1.7.24" % "test",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.24" % "test",
-    "org.slf4j" % "jul-to-slf4j" % "1.7.24" % "test",
-    "org.slf4j" % "log4j-over-slf4j" % "1.7.24" % "test",
+    "org.slf4j" % "slf4j-api" % "1.7.25" % "test",
+    "org.slf4j" % "jcl-over-slf4j" % "1.7.25" % "test",
+    "org.slf4j" % "jul-to-slf4j" % "1.7.25" % "test",
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % "test",
     "ch.qos.logback" % "logback-classic" % "1.2.1" % "test"
   ),
   excludeDependencies ++= Seq(


### PR DESCRIPTION
Upgrade the following depedencies:

* Hadoop from `2.7.3` to `2.7.4`.
* Spark from `2.1.0` to `2.1.2`.
* Circe from `0.7.0` to `0.8.0`.
* Scalaz from `7.2.9` to `7.2.16`.
* SLF4J and adapter libs from `1.7.24` to `1.7.25`.

These should be non-breaking changes for you with the exception of
Circe, which is why we have bumped the major version to `1.7.0`.