### PR TITLE
Backport v1.7.x: Fix signed publishing and maven central validation failures.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,6 @@ val pomInfo = (
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <scm>
-    <url>git@github.com:intenthq/pucket.git</url>
-    <connection>scm:git:git@github.com:intenthq/pucket.git</connection>
-  </scm>
   <developers>
     <developer>
       <id>intenthq</id>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.cavorite" % "sbt-avro-1-7" % "1.1.2")
 addSbtPlugin("com.intenthq.sbt" % "sbt-thrift-plugin" % "1.0.5")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")


### PR DESCRIPTION
Fix publishing for GPG2 by going back to v1.1.0 of `sbt-pgp` (see
comments on PR at https://github.com/sbt/sbt-pgp/pull/117). We'll go
forward again when a fix is present.

The SCM is now added automatically to the POM by newer versions of SBT,
so this causes a validation failure when publishing to maven central.